### PR TITLE
feat: Store number of components in parsed state

### DIFF
--- a/tests/snapshots/test_serde__basic.snap
+++ b/tests/snapshots/test_serde__basic.snap
@@ -10,7 +10,8 @@ expression: "&release(\"@foo.bar.baz--blah@1.2.3-dev+BUILD-code\")"
     "minor": 2,
     "patch": 3,
     "pre": "dev",
-    "build_code": "BUILD-code"
+    "build_code": "BUILD-code",
+    "components": 3
   },
   "build_hash": null,
   "description": "1.2.3-dev (BUILD-code)"

--- a/tests/snapshots/test_serde__mobile_dotted_secondary.snap
+++ b/tests/snapshots/test_serde__mobile_dotted_secondary.snap
@@ -10,8 +10,9 @@ expression: "&release(\"foo.bar.baz.App@1.0+1.0.200\")"
     "minor": 0,
     "patch": 0,
     "pre": null,
-    "build_code": "1.0.200"
+    "build_code": "1.0.200",
+    "components": 2
   },
   "build_hash": null,
-  "description": "1.0.0 (1.0.200)"
+  "description": "1.0 (1.0.200)"
 }

--- a/tests/snapshots/test_serde__mobile_three_components.snap
+++ b/tests/snapshots/test_serde__mobile_three_components.snap
@@ -1,18 +1,18 @@
 ---
 source: tests/test_serde.rs
-expression: "&release(\"foo.bar.baz.App@1.0+20200101100\")"
+expression: "&release(\"foo.bar.baz.App@1.0.0+20200101100\")"
 ---
 {
   "package": "foo.bar.baz.App",
-  "version_raw": "1.0+20200101100",
+  "version_raw": "1.0.0+20200101100",
   "version_parsed": {
     "major": 1,
     "minor": 0,
     "patch": 0,
     "pre": null,
     "build_code": "20200101100",
-    "components": 2
+    "components": 3
   },
   "build_hash": null,
-  "description": "1.0 (20200101100)"
+  "description": "1.0.0 (20200101100)"
 }

--- a/tests/snapshots/test_serde__single_component.snap
+++ b/tests/snapshots/test_serde__single_component.snap
@@ -1,0 +1,18 @@
+---
+source: tests/test_serde.rs
+expression: "&release(\"com.foogame.FooGame@7211+7211\")"
+---
+{
+  "package": "com.foogame.FooGame",
+  "version_raw": "7211+7211",
+  "version_parsed": {
+    "major": 7211,
+    "minor": 0,
+    "patch": 0,
+    "pre": null,
+    "build_code": "7211",
+    "components": 1
+  },
+  "build_hash": null,
+  "description": "7211 (7211)"
+}

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -37,9 +37,9 @@ fn test_basic_short_ver() {
     assert_eq!(version.build_code(), Some("build-code"));
 
     assert_eq!(release.build_hash(), None);
-    assert_eq!(release.to_string(), "@foo.bar.baz--blah@1.0.0-a+build-code");
+    assert_eq!(release.to_string(), "@foo.bar.baz--blah@1.0-a+build-code");
 
-    assert_eq!(release.describe().to_string(), "1.0.0-a (build-code)");
+    assert_eq!(release.describe().to_string(), "1.0-a (build-code)");
 }
 
 #[test]
@@ -105,10 +105,10 @@ fn test_release_build_note_is_hash() {
     );
     assert_eq!(
         release.to_string(),
-        "@foo.bar.baz--blah@1.0.0-a+a86d127c4b2f23a0a862620280427dcc01c78676"
+        "@foo.bar.baz--blah@1.0-a+a86d127c4b2f23a0a862620280427dcc01c78676"
     );
 
-    assert_eq!(release.describe().to_string(), "1.0.0-a (a86d127c4b2f)");
+    assert_eq!(release.describe().to_string(), "1.0-a (a86d127c4b2f)");
 }
 
 #[test]
@@ -152,10 +152,10 @@ fn test_basic_ios_ver() {
     assert_eq!(release.build_hash(), None);
     assert_eq!(
         release.to_string(),
-        "org.example.FooApp@1.0.0-rc1+20200101100"
+        "org.example.FooApp@1.0-rc1+20200101100"
     );
 
-    assert_eq!(release.describe().to_string(), "1.0.0-rc1 (20200101100)");
+    assert_eq!(release.describe().to_string(), "1.0-rc1 (20200101100)");
 }
 
 #[test]
@@ -173,9 +173,9 @@ fn test_basic_ios_ver2() {
     assert_eq!(version.build_code(), Some("1.2.3"));
 
     assert_eq!(release.build_hash(), None);
-    assert_eq!(release.to_string(), "org.example.FooApp@1.0.0-rc1+1.2.3");
+    assert_eq!(release.to_string(), "org.example.FooApp@1.0-rc1+1.2.3");
 
-    assert_eq!(release.describe().to_string(), "1.0.0-rc1 (1.2.3)");
+    assert_eq!(release.describe().to_string(), "1.0-rc1 (1.2.3)");
 }
 
 #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -21,6 +21,11 @@ fn test_mobile() {
 }
 
 #[test]
+fn test_mobile_three_components() {
+    release_snapshot!("foo.bar.baz.App@1.0.0+20200101100");
+}
+
+#[test]
 fn test_mobile_dotted_secondary() {
     release_snapshot!("foo.bar.baz.App@1.0+1.0.200");
 }
@@ -33,4 +38,9 @@ fn test_hash() {
 #[test]
 fn test_qualified_hash() {
     release_snapshot!("package@085240e737828d8326719bf97730188e927e49ca");
+}
+
+#[test]
+fn test_single_component() {
+    release_snapshot!("com.foogame.FooGame@7211+7211");
 }


### PR DESCRIPTION
This changes the parser so that `1.0` and `1.0.0` are remembered as different
in the parsed state.