### PR TITLE
feat: Expand version format to four components

### DIFF
--- a/parser.test.js
+++ b/parser.test.js
@@ -3,7 +3,7 @@ const { Release } = require("./lib/parser.js");
 
 test("parse snapshots", () => {
   // check against the rust snapshots
-  fs.readdirSync("tests/snapshots").forEach(snap => {
+  fs.readdirSync("tests/snapshots").forEach((snap) => {
     const match = fs
       .readFileSync(`tests/snapshots/${snap}`, "utf-8")
       .match(/expression: \"&release\((.*?)\)\"\n.*?---\n(.*)?$/s);
@@ -18,6 +18,8 @@ test("parse snapshots", () => {
       expect(v.major).toEqual(output.version_parsed.major);
       expect(v.minor).toEqual(output.version_parsed.minor);
       expect(v.patch).toEqual(output.version_parsed.patch);
+      expect(v.revision).toEqual(output.version_parsed.revision);
+      expect(v.rawQuad).toEqual(output.version_parsed.raw_quad);
       expect(v.pre || null).toEqual(output.version_parsed.pre || null);
       expect(v.buildCode || null).toEqual(
         output.version_parsed.build_code || null

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -409,11 +409,10 @@ pub struct ReleaseDescription<'a>(&'a Release<'a>);
 
 impl<'a> fmt::Display for ReleaseDescription<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let short_hash = if let Some(hash) = self.0.build_hash() {
-            Some(hash.get(..12).unwrap_or(hash))
-        } else {
-            None
-        };
+        let short_hash = self
+            .0
+            .build_hash()
+            .map(|hash| hash.get(..12).unwrap_or(hash));
 
         if let Some(ver) = self.0.version() {
             fmt::Display::fmt(&VersionDescription(ver), f)?;

--- a/tests/snapshots/test_serde__basic.snap
+++ b/tests/snapshots/test_serde__basic.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"@foo.bar.baz--blah@1.2.3-dev+BUILD-code\")"
+
 ---
 {
   "package": "@foo.bar.baz--blah",
@@ -9,9 +10,16 @@ expression: "&release(\"@foo.bar.baz--blah@1.2.3-dev+BUILD-code\")"
     "major": 1,
     "minor": 2,
     "patch": 3,
+    "revision": 0,
     "pre": "dev",
     "build_code": "BUILD-code",
-    "components": 3
+    "components": 3,
+    "raw_quad": [
+      "1",
+      "2",
+      "3",
+      null
+    ]
   },
   "build_hash": null,
   "description": "1.2.3-dev (BUILD-code)"

--- a/tests/snapshots/test_serde__basic_prerelease.snap
+++ b/tests/snapshots/test_serde__basic_prerelease.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"some-api@1.2.3-test\")"
+
 ---
 {
   "package": "some-api",
@@ -9,9 +10,16 @@ expression: "&release(\"some-api@1.2.3-test\")"
     "major": 1,
     "minor": 2,
     "patch": 3,
+    "revision": 0,
     "pre": "test",
     "build_code": null,
-    "components": 3
+    "components": 3,
+    "raw_quad": [
+      "1",
+      "2",
+      "3",
+      null
+    ]
   },
   "build_hash": null,
   "description": "1.2.3-test"

--- a/tests/snapshots/test_serde__four_components.snap
+++ b/tests/snapshots/test_serde__four_components.snap
@@ -1,26 +1,26 @@
 ---
 source: tests/test_serde.rs
-expression: "&release(\"some-api@1.0-1234\")"
+expression: "&release(\"some-api@1.0.0.0\")"
 
 ---
 {
   "package": "some-api",
-  "version_raw": "1.0-1234",
+  "version_raw": "1.0.0.0",
   "version_parsed": {
     "major": 1,
     "minor": 0,
     "patch": 0,
     "revision": 0,
-    "pre": "1234",
+    "pre": null,
     "build_code": null,
-    "components": 2,
+    "components": 4,
     "raw_quad": [
       "1",
       "0",
-      null,
-      null
+      "0",
+      "0"
     ]
   },
   "build_hash": null,
-  "description": "1.0-1234"
+  "description": "1.0.0.0"
 }

--- a/tests/snapshots/test_serde__implied_prerelease.snap
+++ b/tests/snapshots/test_serde__implied_prerelease.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"some-api@1.0alpha2\")"
+
 ---
 {
   "package": "some-api",
@@ -9,9 +10,16 @@ expression: "&release(\"some-api@1.0alpha2\")"
     "major": 1,
     "minor": 0,
     "patch": 0,
+    "revision": 0,
     "pre": "alpha2",
     "build_code": null,
-    "components": 2
+    "components": 2,
+    "raw_quad": [
+      "1",
+      "0",
+      null,
+      null
+    ]
   },
   "build_hash": null,
   "description": "1.0-alpha2"

--- a/tests/snapshots/test_serde__leading_zeroes.snap
+++ b/tests/snapshots/test_serde__leading_zeroes.snap
@@ -1,0 +1,26 @@
+---
+source: tests/test_serde.rs
+expression: "&release(\"foo@01.02.003.4-alpha+1234\")"
+
+---
+{
+  "package": "foo",
+  "version_raw": "01.02.003.4-alpha+1234",
+  "version_parsed": {
+    "major": 1,
+    "minor": 2,
+    "patch": 3,
+    "revision": 4,
+    "pre": "alpha",
+    "build_code": "1234",
+    "components": 4,
+    "raw_quad": [
+      "01",
+      "02",
+      "003",
+      "4"
+    ]
+  },
+  "build_hash": null,
+  "description": "01.02.003.4-alpha (1234)"
+}

--- a/tests/snapshots/test_serde__mobile.snap
+++ b/tests/snapshots/test_serde__mobile.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"foo.bar.baz.App@1.0+20200101100\")"
+
 ---
 {
   "package": "foo.bar.baz.App",
@@ -9,9 +10,16 @@ expression: "&release(\"foo.bar.baz.App@1.0+20200101100\")"
     "major": 1,
     "minor": 0,
     "patch": 0,
+    "revision": 0,
     "pre": null,
     "build_code": "20200101100",
-    "components": 2
+    "components": 2,
+    "raw_quad": [
+      "1",
+      "0",
+      null,
+      null
+    ]
   },
   "build_hash": null,
   "description": "1.0 (20200101100)"

--- a/tests/snapshots/test_serde__mobile_dotted_secondary.snap
+++ b/tests/snapshots/test_serde__mobile_dotted_secondary.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"foo.bar.baz.App@1.0+1.0.200\")"
+
 ---
 {
   "package": "foo.bar.baz.App",
@@ -9,9 +10,16 @@ expression: "&release(\"foo.bar.baz.App@1.0+1.0.200\")"
     "major": 1,
     "minor": 0,
     "patch": 0,
+    "revision": 0,
     "pre": null,
     "build_code": "1.0.200",
-    "components": 2
+    "components": 2,
+    "raw_quad": [
+      "1",
+      "0",
+      null,
+      null
+    ]
   },
   "build_hash": null,
   "description": "1.0 (1.0.200)"

--- a/tests/snapshots/test_serde__mobile_three_components.snap
+++ b/tests/snapshots/test_serde__mobile_three_components.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"foo.bar.baz.App@1.0.0+20200101100\")"
+
 ---
 {
   "package": "foo.bar.baz.App",
@@ -9,9 +10,16 @@ expression: "&release(\"foo.bar.baz.App@1.0.0+20200101100\")"
     "major": 1,
     "minor": 0,
     "patch": 0,
+    "revision": 0,
     "pre": null,
     "build_code": "20200101100",
-    "components": 3
+    "components": 3,
+    "raw_quad": [
+      "1",
+      "0",
+      "0",
+      null
+    ]
   },
   "build_hash": null,
   "description": "1.0.0 (20200101100)"

--- a/tests/snapshots/test_serde__single_component.snap
+++ b/tests/snapshots/test_serde__single_component.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"com.foogame.FooGame@7211+7211\")"
+
 ---
 {
   "package": "com.foogame.FooGame",
@@ -9,9 +10,16 @@ expression: "&release(\"com.foogame.FooGame@7211+7211\")"
     "major": 7211,
     "minor": 0,
     "patch": 0,
+    "revision": 0,
     "pre": null,
     "build_code": "7211",
-    "components": 1
+    "components": 1,
+    "raw_quad": [
+      "7211",
+      null,
+      null,
+      null
+    ]
   },
   "build_hash": null,
   "description": "7211 (7211)"

--- a/tests/snapshots/test_serde__valid_dotted_release.snap
+++ b/tests/snapshots/test_serde__valid_dotted_release.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_serde.rs
 expression: "&release(\"some-api@2020.2-1.2.3\")"
+
 ---
 {
   "package": "some-api",
@@ -9,9 +10,16 @@ expression: "&release(\"some-api@2020.2-1.2.3\")"
     "major": 2020,
     "minor": 2,
     "patch": 0,
+    "revision": 0,
     "pre": "1.2.3",
     "build_code": null,
-    "components": 2
+    "components": 2,
+    "raw_quad": [
+      "2020",
+      "2",
+      null,
+      null
+    ]
   },
   "build_hash": null,
   "description": "2020.2-1.2.3"

--- a/tests/snapshots/test_serde__version_only.snap
+++ b/tests/snapshots/test_serde__version_only.snap
@@ -1,0 +1,12 @@
+---
+source: tests/test_serde.rs
+expression: "&release(\"foo@20210505090610352561\")"
+
+---
+{
+  "package": "foo",
+  "version_raw": "20210505090610352561",
+  "version_parsed": null,
+  "build_hash": "20210505090610352561",
+  "description": "202105050906"
+}

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -1,5 +1,5 @@
-use similar_asserts::assert_eq;
 use sentry_release_parser::{InvalidRelease, Release};
+use similar_asserts::assert_eq;
 
 #[test]
 fn test_basic() {
@@ -137,11 +137,18 @@ fn test_release_build_note_is_hash() {
 
 #[test]
 fn test_four_component_version() {
-    let release = Release::parse("foo.bar.baz@1.2.3.4").unwrap();
+    let release = Release::parse("foo.bar.baz@1.2.3.04").unwrap();
     assert_eq!(release.package(), Some("foo.bar.baz"));
-    assert_eq!(release.version_raw(), "1.2.3.4");
-    assert_eq!(release.version(), None);
-    assert_eq!(release.to_string(), "foo.bar.baz@1.2.3.4");
+    assert_eq!(release.version_raw(), "1.2.3.04");
+    let version = release.version().unwrap();
+    assert_eq!(version.major(), 1);
+    assert_eq!(version.minor(), 2);
+    assert_eq!(version.patch(), 3);
+    assert_eq!(version.revision(), 4);
+    assert_eq!(version.triple(), (1, 2, 3));
+    assert_eq!(version.quad(), (1, 2, 3, 4));
+    assert_eq!(version.raw_quad(), ("1", Some("2"), Some("3"), Some("04")));
+    assert_eq!(release.to_string(), "foo.bar.baz@1.2.3.04");
 }
 
 #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -66,6 +66,21 @@ fn test_implied_prerelease() {
 }
 
 #[test]
+fn test_four_components() {
+    assert_release_snapshot!("some-api@1.0.0.0");
+}
+
+#[test]
 fn test_dashed_numeric_prerelease() {
     assert_release_snapshot!("some-api@1.0-1234");
+}
+
+#[test]
+fn test_leading_zeroes() {
+    assert_release_snapshot!("foo@01.02.003.4-alpha+1234");
+}
+
+#[test]
+fn test_version_only() {
+    assert_release_snapshot!("foo@20210505090610352561");
 }


### PR DESCRIPTION
This expands our version format to four components and retains leading
zeros in formatting.  The intention is to support more flexible version
formats some of which are common in the Microsoft environment where
versions are in the form `major.minor.build.revision`.  We map these to
`major.minor.patch.revision`.

The previous code encouraged code to look at `components` to determine how
many dots to render.  Now it's better to look at `rawQuad` which tells you exactly
how the components that make up the quad were formatted before parsing.