### PR TITLE
ci(craft): Fix config for GHA and new Craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,10 +1,5 @@
-minVersion: '0.9.0'
-github:
-    owner: getsentry
-    repo: sentry-release-parser
+minVersion: '0.22.2'
 changelogPolicy: none
-statusProvider: 
-    name: github
 preReleaseCommand: ./scripts/bump-version.sh
 targets:
     - name: github


### PR DESCRIPTION
Fixes the failed run over at https://github.com/getsentry/publish/runs/2674223500?check_suite_focus=true