### PR TITLE
feat: Reject empty versions as invalid

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ use serde::{
 };
 
 lazy_static! {
-    static ref RELEASE_REGEX: Regex = Regex::new(r#"^(@?[^@]+)@(.*?)$"#).unwrap();
+    static ref RELEASE_REGEX: Regex = Regex::new(r#"^(@?[^@]+)@(.+?)$"#).unwrap();
     static ref VERSION_REGEX: Regex = Regex::new(
         r#"(?x)
         ^

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-const RELEASE_REGEX = /^(@?[^@]+)@(.*?)$/;
+const RELEASE_REGEX = /^(@?[^@]+)@(.+?)$/;
 const VERSION_REGEX = new RegExp(
   `^
     ([0-9][0-9]*)

--- a/tests/snapshots/test_serde__empty_version.snap
+++ b/tests/snapshots/test_serde__empty_version.snap
@@ -1,0 +1,12 @@
+---
+source: tests/test_serde.rs
+expression: "&release(\"foo@\")"
+
+---
+{
+  "package": null,
+  "version_raw": "foo@",
+  "version_parsed": null,
+  "build_hash": null,
+  "description": "foo@"
+}

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -84,3 +84,8 @@ fn test_leading_zeroes() {
 fn test_version_only() {
     assert_release_snapshot!("foo@20210505090610352561");
 }
+
+#[test]
+fn test_empty_version() {
+    assert_release_snapshot!("foo@");
+}


### PR DESCRIPTION
This now makes `foo@` a release that does not parse as having an embedded version info. This makes generally more sense and means the UI does not have to special case "empty version" or something along those lines.