### PR TITLE
fix: Check restricted names case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Apply case insensitive checks for restricted release and environment names. ([#18](https://github.com/getsentry/sentry-release-parser/pull/18))
+
 ## 1.1.0
 
 - Add validation functions for releases and environments. ([#17](https://github.com/getsentry/sentry-release-parser/pull/17))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -319,7 +319,7 @@ impl<'a> Serialize for Release<'a> {
 pub fn validate_release(release: &str) -> Result<(), InvalidRelease> {
     if release.len() > 200 {
         Err(InvalidRelease::TooLong)
-    } else if release == "." || release == ".." || release == "latest" {
+    } else if release == "." || release == ".." || release.eq_ignore_ascii_case("latest") {
         Err(InvalidRelease::RestrictedName)
     } else if !VALID_API_ATTRIBUTE_REGEX.is_match(release) {
         Err(InvalidRelease::BadCharacters)
@@ -332,7 +332,8 @@ pub fn validate_release(release: &str) -> Result<(), InvalidRelease> {
 pub fn validate_environment(environment: &str) -> Result<(), InvalidEnvironment> {
     if environment.len() > 64 {
         Err(InvalidEnvironment::TooLong)
-    } else if environment == "." || environment == ".." || environment == "none" {
+    } else if environment == "." || environment == ".." || environment.eq_ignore_ascii_case("none")
+    {
         Err(InvalidEnvironment::RestrictedName)
     } else if !VALID_API_ATTRIBUTE_REGEX.is_match(environment) {
         Err(InvalidEnvironment::BadCharacters)


### PR DESCRIPTION
Applies case insensitive checks for restricted release and environment names, following the logic in https://github.com/getsentry/relay/pull/479.