### PR TITLE
ci(gha): Add test and lint jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,20 @@
-name: build
+name: Build
+
 on:
   push:
     branches:
-      - master
       - release/**
-  pull_request:
 
 jobs:
   build:
-    name: build
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - run: make test
+      - run: yarn pack
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
           path: |
             ${{ github.workspace }}/*.tgz
-            # TODO(byk): Update here with what we expect from `cargo build`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,25 @@ jobs:
         with:
           command: doc
           args: --all-features --document-private-items --no-deps
+
+  js:
+    name: JS Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: volta-cli/action@v1
+
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
+
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --forzen-lockfile
+
+      - run: |
+          yarn build
+          yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - release/**
+
+  pull_request:
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy, rustfmt
+          override: true
+
+      - uses: swatinem/rust-cache@v1
+
+      - name: Run Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --tests -- -D clippy::all
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: swatinem/rust-cache@v1
+
+      - name: Run Cargo Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+
+  doc:
+    name: Docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rust-docs
+          override: true
+
+      - uses: swatinem/rust-cache@v1
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all-features --document-private-items --no-deps


### PR DESCRIPTION
Adds a Rust CI workflow aligned with Relay, Symbolic, and Symbolicator. Also
merges the current JS build & test workflow into CI.

These jobs will be marked as required for PR merges.
