### PR TITLE
fix: Single component pre-releases require dash

### DIFF
--- a/parser.test.js
+++ b/parser.test.js
@@ -24,6 +24,8 @@ test("parse snapshots", () => {
       expect(v.buildCode || null).toEqual(
         output.version_parsed.build_code || null
       );
+    } else {
+      expect(parsedRelease.versionParsed).toEqual(undefined);
     }
   });
 });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -154,6 +154,14 @@ impl<'a> Version<'a> {
             + caps.get(2).map_or(0, |_| 1)
             + caps.get(3).map_or(0, |_| 1)
             + caps.get(4).map_or(0, |_| 1);
+
+        // this is a special case we don't want to capture with a regex.  If there is only one
+        // single version component and the pre-release marker does not start with a dash, we
+        // consider it.  This means 1.0a1 is okay, 1-a1 is as well, but 1a1 is not.
+        if components == 1 && caps.get(5).map_or(false, |x| !x.as_str().starts_with('-')) {
+            return Err(InvalidVersion);
+        }
+
         Ok(Version {
             raw: version,
             major: caps.get(1).map(|x| x.as_str()).unwrap_or_default(),
@@ -165,7 +173,7 @@ impl<'a> Version<'a> {
                 .map(|x| {
                     let mut pre = x.as_str();
                     if pre.starts_with('-') {
-                        pre = &pre[1..]
+                        pre = &pre[1..];
                     }
                     pre
                 })

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -137,6 +137,15 @@ function parseVersion(version: string): Version | null {
   }
 
   let pre = match[5] || undefined;
+
+  // this is a special case we don't want to capture with a regex. If there is
+  // only one single version component and the pre-release marker does not start
+  // with a dash, we consider it. This means 1.0a1 is okay, 1-a1 is as well, but
+  // 1a1 is not.
+  if (!match[2] && pre && !pre.match(/^-/)) {
+    return null;
+  }
+
   if (pre && pre[0] == "-") {
     pre = pre.substr(1);
   }

--- a/tests/snapshots/test_serde__not_a_version.snap
+++ b/tests/snapshots/test_serde__not_a_version.snap
@@ -1,0 +1,12 @@
+---
+source: tests/test_serde.rs
+expression: "&release(\"hackweek@6f85d2f\")"
+
+---
+{
+  "package": "hackweek",
+  "version_raw": "6f85d2f",
+  "version_parsed": null,
+  "build_hash": null,
+  "description": "hackweek@6f85d2f"
+}

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -89,3 +89,8 @@ fn test_version_only() {
 fn test_empty_version() {
     assert_release_snapshot!("foo@");
 }
+
+#[test]
+fn test_not_a_version() {
+    assert_release_snapshot!("hackweek@6f85d2f");
+}


### PR DESCRIPTION
This changes the parser so that a single component version requires a separator to the pre-release version. Before `1a` was parsed the same way as `1.0.0-a`. The result of this is that sha1 hashes like `hackweek@6f85d2f` would be parsed as if they are `6.0.0-f85d2f`.