### PR TITLE
feat: retain raw formatting in version text description

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -34,6 +34,7 @@ export interface Version {
   revision: number;
   pre?: string;
   buildCode?: string;
+  rawShort: string;
   components: number;
   rawQuad: [string, string | null, string | null, string | null];
 }
@@ -88,20 +89,7 @@ export class Release {
     const v = this.versionParsed;
     let rv = "";
     if (v) {
-      const [major, minor, patch, revision] = v.rawQuad;
-      rv += major;
-      if (minor) {
-        rv += `.${minor}`;
-      }
-      if (patch) {
-        rv += `.${patch}`;
-      }
-      if (revision) {
-        rv += `.${revision}`;
-      }
-      if (v.pre) {
-        rv += "-" + v.pre;
-      }
+      rv += v.rawShort;
       if (shortHash) {
         rv += ` (${shortHash})`;
       } else if (v.buildCode) {
@@ -158,6 +146,8 @@ function parseVersion(version: string): Version | null {
   ];
   const components = rawQuad.reduce((acc, cur) => acc + (cur ? 1 : 0), 0);
 
+  const rawShort = match[6] ? version.substr(0, version.indexOf("+")) : version;
+
   return {
     raw: version,
     major: parseInt(match[1], 10),
@@ -166,6 +156,7 @@ function parseVersion(version: string): Version | null {
     revision: parseInt(match[4] || "0", 10),
     pre,
     buildCode: match[6] || undefined,
+    rawShort,
     components,
     rawQuad,
   };

--- a/tests/snapshots/test_serde__basic.snap
+++ b/tests/snapshots/test_serde__basic.snap
@@ -13,6 +13,7 @@ expression: "&release(\"@foo.bar.baz--blah@1.2.3-dev+BUILD-code\")"
     "revision": 0,
     "pre": "dev",
     "build_code": "BUILD-code",
+    "raw_short": "1.2.3-dev",
     "components": 3,
     "raw_quad": [
       "1",

--- a/tests/snapshots/test_serde__basic_prerelease.snap
+++ b/tests/snapshots/test_serde__basic_prerelease.snap
@@ -13,6 +13,7 @@ expression: "&release(\"some-api@1.2.3-test\")"
     "revision": 0,
     "pre": "test",
     "build_code": null,
+    "raw_short": "1.2.3-test",
     "components": 3,
     "raw_quad": [
       "1",

--- a/tests/snapshots/test_serde__dashed_numeric_prerelease.snap
+++ b/tests/snapshots/test_serde__dashed_numeric_prerelease.snap
@@ -13,6 +13,7 @@ expression: "&release(\"some-api@1.0-1234\")"
     "revision": 0,
     "pre": "1234",
     "build_code": null,
+    "raw_short": "1.0-1234",
     "components": 2,
     "raw_quad": [
       "1",

--- a/tests/snapshots/test_serde__four_components.snap
+++ b/tests/snapshots/test_serde__four_components.snap
@@ -13,6 +13,7 @@ expression: "&release(\"some-api@1.0.0.0\")"
     "revision": 0,
     "pre": null,
     "build_code": null,
+    "raw_short": "1.0.0.0",
     "components": 4,
     "raw_quad": [
       "1",

--- a/tests/snapshots/test_serde__hash_on_dotted_quad_version.snap
+++ b/tests/snapshots/test_serde__hash_on_dotted_quad_version.snap
@@ -1,0 +1,27 @@
+---
+source: tests/test_serde.rs
+expression: "&release(\"bla-internal@0.0.0.4bfe251b96\")"
+
+---
+{
+  "package": "bla-internal",
+  "version_raw": "0.0.0.4bfe251b96",
+  "version_parsed": {
+    "major": 0,
+    "minor": 0,
+    "patch": 0,
+    "revision": 4,
+    "pre": "bfe251b96",
+    "build_code": null,
+    "raw_short": "0.0.0.4bfe251b96",
+    "components": 4,
+    "raw_quad": [
+      "0",
+      "0",
+      "0",
+      "4"
+    ]
+  },
+  "build_hash": null,
+  "description": "0.0.0.4bfe251b96"
+}

--- a/tests/snapshots/test_serde__hash_on_dotted_two_version.snap
+++ b/tests/snapshots/test_serde__hash_on_dotted_two_version.snap
@@ -1,0 +1,27 @@
+---
+source: tests/test_serde.rs
+expression: "&release(\"bla-internal@1.0dev1\")"
+
+---
+{
+  "package": "bla-internal",
+  "version_raw": "1.0dev1",
+  "version_parsed": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0,
+    "revision": 0,
+    "pre": "dev1",
+    "build_code": null,
+    "raw_short": "1.0dev1",
+    "components": 2,
+    "raw_quad": [
+      "1",
+      "0",
+      null,
+      null
+    ]
+  },
+  "build_hash": null,
+  "description": "1.0dev1"
+}

--- a/tests/snapshots/test_serde__implied_prerelease.snap
+++ b/tests/snapshots/test_serde__implied_prerelease.snap
@@ -13,6 +13,7 @@ expression: "&release(\"some-api@1.0alpha2\")"
     "revision": 0,
     "pre": "alpha2",
     "build_code": null,
+    "raw_short": "1.0alpha2",
     "components": 2,
     "raw_quad": [
       "1",
@@ -22,5 +23,5 @@ expression: "&release(\"some-api@1.0alpha2\")"
     ]
   },
   "build_hash": null,
-  "description": "1.0-alpha2"
+  "description": "1.0alpha2"
 }

--- a/tests/snapshots/test_serde__leading_zeroes.snap
+++ b/tests/snapshots/test_serde__leading_zeroes.snap
@@ -13,6 +13,7 @@ expression: "&release(\"foo@01.02.003.4-alpha+1234\")"
     "revision": 4,
     "pre": "alpha",
     "build_code": "1234",
+    "raw_short": "01.02.003.4-alpha",
     "components": 4,
     "raw_quad": [
       "01",

--- a/tests/snapshots/test_serde__mobile.snap
+++ b/tests/snapshots/test_serde__mobile.snap
@@ -13,6 +13,7 @@ expression: "&release(\"foo.bar.baz.App@1.0+20200101100\")"
     "revision": 0,
     "pre": null,
     "build_code": "20200101100",
+    "raw_short": "1.0",
     "components": 2,
     "raw_quad": [
       "1",

--- a/tests/snapshots/test_serde__mobile_dotted_secondary.snap
+++ b/tests/snapshots/test_serde__mobile_dotted_secondary.snap
@@ -13,6 +13,7 @@ expression: "&release(\"foo.bar.baz.App@1.0+1.0.200\")"
     "revision": 0,
     "pre": null,
     "build_code": "1.0.200",
+    "raw_short": "1.0",
     "components": 2,
     "raw_quad": [
       "1",

--- a/tests/snapshots/test_serde__mobile_three_components.snap
+++ b/tests/snapshots/test_serde__mobile_three_components.snap
@@ -13,6 +13,7 @@ expression: "&release(\"foo.bar.baz.App@1.0.0+20200101100\")"
     "revision": 0,
     "pre": null,
     "build_code": "20200101100",
+    "raw_short": "1.0.0",
     "components": 3,
     "raw_quad": [
       "1",

--- a/tests/snapshots/test_serde__single_component.snap
+++ b/tests/snapshots/test_serde__single_component.snap
@@ -13,6 +13,7 @@ expression: "&release(\"com.foogame.FooGame@7211+7211\")"
     "revision": 0,
     "pre": null,
     "build_code": "7211",
+    "raw_short": "7211",
     "components": 1,
     "raw_quad": [
       "7211",

--- a/tests/snapshots/test_serde__valid_dotted_release.snap
+++ b/tests/snapshots/test_serde__valid_dotted_release.snap
@@ -13,6 +13,7 @@ expression: "&release(\"some-api@2020.2-1.2.3\")"
     "revision": 0,
     "pre": "1.2.3",
     "build_code": null,
+    "raw_short": "2020.2-1.2.3",
     "components": 2,
     "raw_quad": [
       "2020",

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -38,9 +38,9 @@ fn test_basic_short_ver() {
     assert_eq!(version.build_code(), Some("build-code"));
 
     assert_eq!(release.build_hash(), None);
-    assert_eq!(release.to_string(), "@foo.bar.baz--blah@1.0-a+build-code");
+    assert_eq!(release.to_string(), "@foo.bar.baz--blah@1.0a+build-code");
 
-    assert_eq!(release.describe().to_string(), "1.0-a (build-code)");
+    assert_eq!(release.describe().to_string(), "1.0a (build-code)");
 }
 
 #[test]
@@ -60,10 +60,10 @@ fn test_basic_short_ver_a2() {
     assert_eq!(release.build_hash(), None);
     assert_eq!(
         release.to_string(),
-        "@foo.bar.baz--blah@1.0-alpha2+build-code"
+        "@foo.bar.baz--blah@1.0alpha2+build-code"
     );
 
-    assert_eq!(release.describe().to_string(), "1.0-alpha2 (build-code)");
+    assert_eq!(release.describe().to_string(), "1.0alpha2 (build-code)");
 }
 
 #[test]
@@ -129,10 +129,10 @@ fn test_release_build_note_is_hash() {
     );
     assert_eq!(
         release.to_string(),
-        "@foo.bar.baz--blah@1.0-a+a86d127c4b2f23a0a862620280427dcc01c78676"
+        "@foo.bar.baz--blah@1.0a+a86d127c4b2f23a0a862620280427dcc01c78676"
     );
 
-    assert_eq!(release.describe().to_string(), "1.0-a (a86d127c4b2f)");
+    assert_eq!(release.describe().to_string(), "1.0a (a86d127c4b2f)");
 }
 
 #[test]
@@ -181,12 +181,9 @@ fn test_basic_ios_ver() {
     assert_eq!(version.build_code(), Some("20200101100"));
 
     assert_eq!(release.build_hash(), None);
-    assert_eq!(
-        release.to_string(),
-        "org.example.FooApp@1.0-rc1+20200101100"
-    );
+    assert_eq!(release.to_string(), "org.example.FooApp@1.0rc1+20200101100");
 
-    assert_eq!(release.describe().to_string(), "1.0-rc1 (20200101100)");
+    assert_eq!(release.describe().to_string(), "1.0rc1 (20200101100)");
 }
 
 #[test]
@@ -204,9 +201,9 @@ fn test_basic_ios_ver2() {
     assert_eq!(version.build_code(), Some("1.2.3"));
 
     assert_eq!(release.build_hash(), None);
-    assert_eq!(release.to_string(), "org.example.FooApp@1.0-rc1+1.2.3");
+    assert_eq!(release.to_string(), "org.example.FooApp@1.0rc1+1.2.3");
 
-    assert_eq!(release.describe().to_string(), "1.0-rc1 (1.2.3)");
+    assert_eq!(release.describe().to_string(), "1.0rc1 (1.2.3)");
 }
 
 #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -94,3 +94,13 @@ fn test_empty_version() {
 fn test_not_a_version() {
     assert_release_snapshot!("hackweek@6f85d2f");
 }
+
+#[test]
+fn test_hash_on_dotted_two_version() {
+    assert_release_snapshot!("bla-internal@1.0dev1");
+}
+
+#[test]
+fn test_hash_on_dotted_quad_version() {
+    assert_release_snapshot!("bla-internal@0.0.0.4bfe251b96");
+}


### PR DESCRIPTION
This changes the formatting of versions to retain the raw format. This is necessary because we keep misparsing some legitimate releases and users end up confused why their build hash is sliced up into a version number.

Before `bla-internal@0.0.0.4bfe251b96` would show up as `0.0.0.4-bfe251b96`, now it remains as `0.0.0.4bfe251b96`.