### PR TITLE
fix: Actually disallow all ASCII control characters [ingest-1204]

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -32,7 +32,7 @@ lazy_static! {
     static ref HEX_REGEX: Regex = Regex::new(r#"^[a-fA-F0-9]+$"#).unwrap();
     // what can or cannot go through the API which is a limiting factor for
     // releases and environments.
-    static ref VALID_API_ATTRIBUTE_REGEX: Regex = Regex::new(r"^[^\\/\r\n\t\x0c\x00]*\z").unwrap();
+    static ref VALID_API_ATTRIBUTE_REGEX: Regex = Regex::new(r"^[^\\/\r\n\t\x7f\x00-\x1f]*\z").unwrap();
 }
 
 /// An error indicating invalid versions.


### PR DESCRIPTION
Syncing with latest changes in https://github.com/getsentry/relay/pull/1235